### PR TITLE
feat: Add custom paths subdirectory depth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ set -g @sessionx-custom-paths '/Users/me/projects,/Users/me/second-brain'
 # under the aforementioned custom paths, e.g. /Users/me/projects/tmux-sessionx
 set -g @sessionx-custom-paths-subdirectories 'false'
 
+# When @sessionx-custom-paths-subdirectories is 'true', this option controls
+# the depth of subdirectories to search within custom paths.
+# Defaults to '1', meaning only direct subdirectories are included.
+# Example: set -g @sessionx-custom-paths-subdirectories-depth '2'
+set -g @sessionx-custom-paths-subdirectories-depth '1'
+
 # Uses `fzf --tmux` instead of the `fzf-tmux` script (requires fzf >= 0.53).
 set -g @sessionx-fzf-builtin-tmux 'on'
 

--- a/scripts/sessionx.sh
+++ b/scripts/sessionx.sh
@@ -50,7 +50,8 @@ additional_input() {
 	else
 		clean_paths=$(echo "$custom_paths" | sed -E 's/ *, */,/g' | sed -E 's/^ *//' | sed -E 's/ *$//' | sed -E 's/ /✗/g')
 		if [[ "$custom_path_subdirectories" == "true" ]]; then
-			paths=$(find ${clean_paths//,/ } -mindepth 1 -maxdepth 1 -type d)
+			custom_depth=$(tmux_option_or_fallback "@sessionx-custom-paths-subdirectories-depth" "1")
+			paths=$(find ${clean_paths//,/ } -mindepth "$custom_depth" -maxdepth "$custom_depth" -type d)
 		else
 			paths=${clean_paths//,/ }
 		fi


### PR DESCRIPTION
This commit introduces a new configuration option to enhance how `sessionx` handles custom paths:

- **New Option:** `@sessionx-custom-paths-subdirectories-depth`
  - Allows users to specify the depth of subdirectory scanning within custom paths.
  - This option is active when `@sessionx-custom-paths-subdirectories` is enabled.
  - Defaults to `1`, meaning only direct subdirectories are included by default.
- **Improved Flexibility:** Provides more granular control over session discovery in deeply nested project structures.